### PR TITLE
Added permanant password storage in the EEPROM.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ WiFi captive portal for the NodeMCU (ESP8266 Module) with DNS spoofing.
 
 The built-in LED will blink 5 times when a password is posted.
 
-<b>Warning!</b> Your saved passwords will disappear when you restart/power off the ESP8266.
+<b>Warning!</b> Your saved passwords will not disappear when you restart/power off the ESP8266 or change the SSID.
 
 <b>Note:</b> If you want to see the stored passwords go to "**172.0.0.1**<a>/pass</a>". For changing the SSID, go to "**172.0.0.1**<a>/ssid</a>"
 


### PR DESCRIPTION
Added permanant password storage in the EEPROM.

EEPROM Memory location:
0-19 -> For storing SSID.
20-END -> For storing password

Password will be stored even after reboot and SSID change.
To delete the password, press the clear button.